### PR TITLE
Add an optional 'force_start_date' configuration

### DIFF
--- a/tap_solarvista/sync.py
+++ b/tap_solarvista/sync.py
@@ -17,6 +17,9 @@ def get_start(entity):
     """ Get the start point for incremental sync """
     if entity not in STATE:
         STATE[entity] = CONFIG['start_date']
+    # when a 'force_start_date' config has been supplied this forces the sync to start from the supplied date
+    if CONFIG.get('force_start_date'):
+        STATE[entity] = CONFIG['force_start_date']
 
     return STATE[entity]
 

--- a/tap_solarvista/sync.py
+++ b/tap_solarvista/sync.py
@@ -17,7 +17,7 @@ def get_start(entity):
     """ Get the start point for incremental sync """
     if entity not in STATE:
         STATE[entity] = CONFIG['start_date']
-    # when a 'force_start_date' config has been supplied this forces the sync to start from the supplied date
+    # 'force_start_date' config forces the sync to start from the supplied date
     if CONFIG.get('force_start_date'):
         STATE[entity] = CONFIG['force_start_date']
 

--- a/tap_solarvista/tests/test_sync.py
+++ b/tap_solarvista/tests/test_sync.py
@@ -79,6 +79,21 @@ class TestSync(unittest.TestCase):
         tap_solarvista.sync.STATE = {}
         responses.reset()
 
+    def test_start_date(self):
+        """ Test basic configuration with a 'start_date' and 'force_start_date' """
+        mock_entity = 'mock_entity'
+        mock_start_date_config = {
+            'start_date': '2021-07-22T08:00:00Z',
+        }
+        tap_solarvista.sync.CONFIG = mock_start_date_config        
+        self.assertEqual(tap_solarvista.sync.get_start(mock_entity), '2021-07-22T08:00:00Z')
+        mock_force_start_date_config = {
+            'start_date': '2021-07-22T08:00:00Z',
+            'force_start_date': '2020-01-01T08:00:00Z',
+        }
+        tap_solarvista.sync.CONFIG = mock_force_start_date_config        
+        self.assertEqual(tap_solarvista.sync.get_start(mock_entity), '2020-01-01T08:00:00Z')
+
     @responses.activate  # intercept HTTP calls within this method
     def test_sync_token(self):
         """ Test basic sync requests token before requesting records """

--- a/tap_solarvista/tests/test_sync.py
+++ b/tap_solarvista/tests/test_sync.py
@@ -85,14 +85,16 @@ class TestSync(unittest.TestCase):
         mock_start_date_config = {
             'start_date': '2021-07-22T08:00:00Z',
         }
-        tap_solarvista.sync.CONFIG = mock_start_date_config        
-        self.assertEqual(tap_solarvista.sync.get_start(mock_entity), '2021-07-22T08:00:00Z')
+        tap_solarvista.sync.CONFIG = mock_start_date_config
+        actual_start_date = tap_solarvista.sync.get_start(mock_entity)
+        self.assertEqual(actual_start_date, '2021-07-22T08:00:00Z')
         mock_force_start_date_config = {
             'start_date': '2021-07-22T08:00:00Z',
             'force_start_date': '2020-01-01T08:00:00Z',
         }
-        tap_solarvista.sync.CONFIG = mock_force_start_date_config        
-        self.assertEqual(tap_solarvista.sync.get_start(mock_entity), '2020-01-01T08:00:00Z')
+        tap_solarvista.sync.CONFIG = mock_force_start_date_config
+        actual_start_date = tap_solarvista.sync.get_start(mock_entity)
+        self.assertEqual(actual_start_date, '2020-01-01T08:00:00Z')
 
     @responses.activate  # intercept HTTP calls within this method
     def test_sync_token(self):


### PR DESCRIPTION
When supplied this configuration will force the sync from the supplied date, ignoring any state for incremental sync of work items.